### PR TITLE
#1 Removed the ship asset and stats render from the default start view.

### DIFF
--- a/Share With Images/ViewController.swift
+++ b/Share With Images/ViewController.swift
@@ -21,13 +21,8 @@ class ViewController: UIViewController, ARSCNViewDelegate {
         sceneView.delegate = self
         
         // Show statistics such as fps and timing information
-        sceneView.showsStatistics = true
-        
-        // Create a new scene
-        let scene = SCNScene(named: "art.scnassets/ship.scn")!
-        
-        // Set the scene to the view
-        sceneView.scene = scene
+        sceneView.showsStatistics = false
+
     }
     
     override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
Resolves #1 . The jet plane (ship asset) and stats are not rendered in the default view