### PR TITLE
Implemented an example for sending an email to a certain recipient

### DIFF
--- a/Share With Images/SharingImage.swift
+++ b/Share With Images/SharingImage.swift
@@ -27,6 +27,7 @@ class SharingImage: NSObject, NSCoding {
     var photo: UIImage
     var photoDescription: String?
     var type: sharingImageType
+    static let sharingEmail: String = "xyz@gmail.com"
     
     //MARK: Archiving Paths
     

--- a/Share With Images/ViewController.swift
+++ b/Share With Images/ViewController.swift
@@ -84,6 +84,12 @@ class ViewController: UIViewController, ARSCNViewDelegate {
         DispatchQueue.main.async {
             let imageName = referenceImage.name ?? ""
             print("Detected image “\(imageName)”")
+            if imageName == "gmail"{
+                let email = "foo@bar.com"
+                if let url = URL(string: "mailto:\(email)") {
+                    UIApplication.shared.open(url)
+                }
+            }
         }
     
         return node


### PR DESCRIPTION
Resolves #6. Implemented a toy example in the 6-sharing-image-trigger-action branch to open the email client using this stack overflow post and an array to store which images have already been shown to the camera. Its currently hardcoded but I still want to merge this branch. I want to define a few templates that identify missing information when presented with some SharingImages and settle on a "good" set of allowed actions before making creating fully user-customizable actions.